### PR TITLE
Fix translation inconsistency

### DIFF
--- a/profiles/oracle/liquibase/changelog/02_codelists/STM_CODELIST.csv
+++ b/profiles/oracle/liquibase/changelog/02_codelists/STM_CODELIST.csv
@@ -51,8 +51,8 @@ COD_ID,COD_LIST,COD_VALUE,COD_SYSTEM,COD_DEFAULT,COD_DESCRIPTION
 50,queryTask.scope,cartography-query,true,false,Cartography Query
 51,queryTask.scope,sql-query,true,false,SQL Query
 52,queryTask.scope,web-api-query,true,false,Web API Query
-53,service.authenticationMode,None,true,true,None
-54,service.authenticationMode,HTTP Basic authentication,true,false,HTTP Basic authentication
+53,service.authenticationMode,HTTP Basic authentication,true,false,HTTP Basic authentication
+54,service.authenticationMode,None,true,true,None
 122,service.authenticationMode,API key,true,false,API key
 123,apiKey.header,X-API-Key,true,true,X-API-Key
 124,apiKey.cookie,X-API-Key,true,true,X-API-Key

--- a/profiles/postgres/liquibase/changelog/02_codelists/STM_CODELIST.csv
+++ b/profiles/postgres/liquibase/changelog/02_codelists/STM_CODELIST.csv
@@ -51,8 +51,8 @@ COD_ID,COD_LIST,COD_VALUE,COD_SYSTEM,COD_DEFAULT,COD_DESCRIPTION
 50,queryTask.scope,cartography-query,true,false,Cartography Query
 51,queryTask.scope,sql-query,true,false,SQL Query
 52,queryTask.scope,web-api-query,true,false,Web API Query
-53,service.authenticationMode,None,true,true,None
-54,service.authenticationMode,HTTP Basic authentication,true,false,HTTP Basic authentication
+53,service.authenticationMode,HTTP Basic authentication,true,false,HTTP Basic authentication
+54,service.authenticationMode,None,true,true,None
 122,service.authenticationMode,API key,true,false,API key
 123,apiKey.header,X-API-Key,true,true,X-API-Key
 124,apiKey.cookie,X-API-Key,true,true,X-API-Key


### PR DESCRIPTION
Fix translation inconsistency that caused non-coherent behavior on service auth method config.
Fixes this:
<img width="1892" height="932" alt="image" src="https://github.com/user-attachments/assets/16d44f86-d578-4153-ba21-c12f67e5b76c" />
<img width="1913" height="939" alt="image" src="https://github.com/user-attachments/assets/72a7a313-6c36-42d4-821c-35afb768ba0d" />
