### PR TITLE
test(e2e): cover print preview map sizing (viewer #160)

### DIFF
--- a/e2e/viewer/fixtures.ts
+++ b/e2e/viewer/fixtures.ts
@@ -32,6 +32,8 @@ export const MIA_CONTROL_TASK_ID = 43;
 export const MIA_PARENT_TASK_ID = 42;
 /** Seed Feature Information control — needed for identify → MIA callback path. */
 export const FEATURE_INFO_TASK_ID = 8;
+/** Seed STM_TASK id for sitna.printMap (STM_TSK_UI TUI_ID 20) — print preview sizing (#160). */
+export const PRINT_MAP_TASK_ID = 20;
 
 /** IDE Menorca (H2 slim fixture + Docker seed): app 12 / territory 4. */
 export const MENORCA_APP_ID = 12;

--- a/e2e/viewer/print-map.spec.ts
+++ b/e2e/viewer/print-map.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  APP_ID,
+  isBackendRequest,
+  readViewerCredentials,
+  TERRITORY_ID,
+} from './fixtures';
+
+/**
+ * Print preview map sizing (#160).
+ *
+ * While the preview is active api-sitna adds `tc-ctl-prnmap-printing` plus a
+ * format class to the map container and sizes it to the page through its own
+ * `css/sitna.css`. `createPdf` then draws the captured canvas into a pdfmake
+ * slot with both dimensions fixed, so a canvas that kept the browser window
+ * shape is stretched to fill the page.
+ *
+ * The viewer component rule for `#mapa` contains an id, so it outweighed those
+ * three-class rules and the map never resized. It is now guarded with
+ * `:not(.tc-ctl-prnmap-printing)` in both map components.
+ */
+
+/** Sizes declared by api-sitna for `.tc-map.tc-ctl-prnmap-printing.<format>`. */
+const PAGE_FORMATS = [
+  { orientation: 'landscape', size: 'a4', width: '1040px', height: '704px' },
+  { orientation: 'portrait', size: 'a4', width: '712px', height: '1034px' },
+] as const;
+
+/**
+ * Deliberately far from both page shapes, so a map left at window size cannot
+ * satisfy either expectation by accident.
+ */
+const WINDOW = { width: 1600, height: 700 };
+
+async function loginAndOpenMap(page: Page): Promise<void> {
+  const credentials = await readViewerCredentials();
+
+  await page.goto('/auth/login');
+  await expect(page.locator('h1')).toBeVisible();
+
+  await page.locator('input[name="username"]').fill(credentials.username);
+  await page.locator('input[name="password"]').fill(credentials.password);
+
+  const authenticate = page.waitForResponse(
+    (response) => isBackendRequest(response, '/authenticate', 'POST') && response.ok(),
+  );
+  const account = page.waitForResponse(
+    (response) => isBackendRequest(response, '/account', 'GET') && response.ok(),
+  );
+
+  await page.locator('form .login-button button').click();
+  await Promise.all([authenticate, account]);
+  await expect(page).toHaveURL(/\/user\/dashboard/);
+
+  const profile = page.waitForResponse(
+    (response) =>
+      isBackendRequest(
+        response,
+        `/config/client/profile/${APP_ID}/${TERRITORY_ID}`,
+        'GET',
+      ) && response.ok(),
+  );
+
+  await page.goto(`/user/map/${APP_ID}/${TERRITORY_ID}`, {
+    waitUntil: 'domcontentloaded',
+  });
+
+  const profileBody = (await (await profile).json()) as {
+    tasks?: Array<{ 'ui-control'?: string }>;
+  };
+  expect(
+    profileBody.tasks?.some((task) => task['ui-control'] === 'sitna.printMap'),
+    'profile must include sitna.printMap (setup task-availability)',
+  ).toBeTruthy();
+
+  await page.locator('#tc-slot-print').waitFor({ state: 'attached', timeout: 90_000 });
+}
+
+/** Opens the left tools panel and expands the print control. */
+async function openPrintPanel(page: Page): Promise<void> {
+  await page.locator('#tools-tab').click();
+  await expect(page.locator('.tc-left-panel')).not.toHaveClass(/tc-collapsed-left/);
+
+  await page.locator('#tc-slot-print > h2').click();
+  await expect(page.locator('#tc-slot-print')).not.toHaveClass(/tc-collapsed/);
+}
+
+test.use({ viewport: WINDOW });
+
+test.describe('Viewer print preview', () => {
+  test('sizes the map to the selected page format', async ({ page }) => {
+    await loginAndOpenMap(page);
+
+    const map = page.locator('#mapa');
+    await expect(map, 'map should fill the window before any preview').toHaveCSS(
+      'width',
+      `${WINDOW.width}px`,
+    );
+    const windowedHeight = await map.evaluate(
+      (element) => getComputedStyle(element).height,
+    );
+
+    await openPrintPanel(page);
+
+    for (const format of PAGE_FORMATS) {
+      const label = `${format.orientation} ${format.size.toUpperCase()}`;
+
+      await page.selectOption('#print-design', format.orientation);
+      await page.selectOption('#print-size', format.size);
+      await page.locator('#tc-slot-print sitna-button.tc-ctl-prnmap-btn').click();
+      await page
+        .locator(
+          `#mapa.tc-ctl-prnmap-printing.tc-ctl-prnmap-${format.orientation}-${format.size}`,
+        )
+        .waitFor({ timeout: 40_000 });
+
+      await expect(map, `map must be ${label} wide while printing`).toHaveCSS(
+        'width',
+        format.width,
+      );
+      await expect(map, `map must be ${label} tall while printing`).toHaveCSS(
+        'height',
+        format.height,
+      );
+
+      await page.locator('.tc-ctl-prnmap-btn-close').click();
+      await page
+        .locator('#mapa:not(.tc-ctl-prnmap-printing)')
+        .waitFor({ timeout: 20_000 });
+
+      await expect(map, 'map must fill the window again after closing').toHaveCSS(
+        'width',
+        `${WINDOW.width}px`,
+      );
+      await expect(map).toHaveCSS('height', windowedHeight);
+    }
+  });
+});

--- a/e2e/viewer/setup/viewer.setup.ts
+++ b/e2e/viewer/setup/viewer.setup.ts
@@ -22,6 +22,7 @@ import {
   MIA_PARENT_TASK_ID,
   NAV_BAR_TASK_ID,
   OVERVIEW_MAP_TASK_ID,
+  PRINT_MAP_TASK_ID,
   QUERYABLE_LEAF_CARTOGRAPHY_ID,
   SEARCH_TASK_ID,
   QUERYABLE_LEAF_MAX_SCALE_DENOMINATOR,
@@ -243,6 +244,7 @@ setup('provision viewer user and secured WMS service', async ({ request }) => {
   // Profile tasks require territory availability. Seed STM_AVAIL_TSK omits
   // sitna.layerCatalog / sitna.legend / workLayerManager / sitna.basemapSelector
   // and map-chrome nav/fullscreen/streetView/overview needed for #135 checks.
+  // sitna.printMap is omitted too; print preview sizing is checked in #160.
   const mapChromeTaskIds = [
     LAYER_CATALOG_TASK_ID,
     LEGEND_TASK_ID,
@@ -257,6 +259,7 @@ setup('provision viewer user and secured WMS service', async ({ request }) => {
     FEATURE_INFO_TASK_ID,
     MIA_CONTROL_TASK_ID,
     MIA_PARENT_TASK_ID,
+    PRINT_MAP_TASK_ID,
     CCAVALLS_MIA_TASK_ID,
   ];
   for (const territoryId of [TERRITORY_ID, MENORCA_TERRITORY_ID]) {
@@ -276,6 +279,26 @@ setup('provision viewer user and secured WMS service', async ({ request }) => {
       ).toBeTruthy();
     }
   }
+
+  // Seed STM_TASK 20 carries a `div: "print"` parameter naming a container the
+  // viewer never renders, so api-sitna throws while building the control and no
+  // print button appears. The seed logo is an external URL; drop both so the print
+  // preview is exercised without leaving the local stack (#160).
+  const patchPrintTask = await request.patch(`/backend/api/tasks/${PRINT_MAP_TASK_ID}`, {
+    headers: {
+      'X-SITMUN-Client': 'admin',
+      'Content-Type': 'application/merge-patch+json',
+    },
+    data: {
+      properties: {
+        parameters: [{ name: 'legend', type: 'object', value: '{"visible":true}' }],
+      },
+    },
+  });
+  expect(
+    patchPrintTask.ok(),
+    `patch print task failed: ${patchPrintTask.status()} ${await patchPrintTask.text()}`,
+  ).toBeTruthy();
 
   // Catalog matrix fixtures (#45): radio Ortofotos needs loadData for title activation;
   // clear Infrarrojo load-by-default so title-click selection is observable; enable

--- a/playwright.viewer.config.ts
+++ b/playwright.viewer.config.ts
@@ -92,5 +92,11 @@ export default defineConfig({
       dependencies: ['viewer-setup'],
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'viewer-print',
+      testMatch: /print-map\.spec\.ts/,
+      dependencies: ['viewer-setup'],
+      use: { ...devices['Desktop Chrome'] },
+    },
   ],
 });


### PR DESCRIPTION
## What this adds

An end-to-end test for the print preview map sizing reported in
sitmun-viewer-app#160, and the fixture work it needs.

**Depends on sitmun/sitmun-viewer-app#170.** The test asserts behaviour that only exists
once that fix is merged and the viewer submodule tip is bumped here. Until then it
fails on purpose — that is what makes it a regression test. This PR deliberately does
not move the submodule pointer.

## The test

`e2e/viewer/print-map.spec.ts`, new `viewer-print` project.

The browser window is set to 1600 x 700, deliberately far from both page shapes, so a
map left at window size cannot satisfy either expectation by accident. The test then
follows the real user path — tools tab, print control header, Print button — and for
each of A4 landscape and A4 portrait asserts that:

1. the map is window width before any preview,
2. it becomes exactly 1040 x 704 (landscape) or 712 x 1034 (portrait) while printing,
3. it returns to window size after the preview is closed.

Two formats rather than one show the map follows the requested page, not a fixed size.
Step 3 shows the fix leaves nothing behind when the user closes the preview.

## Fixture work

- `PRINT_MAP_TASK_ID` (seed `STM_TASK` 20) added to the map-chrome availability list,
  as the seed `STM_AVAIL_TSK` omits it.
- The setup patches that task's `properties`. The seed carries
  `div: "print"`, naming a container the viewer never renders; `api-sitna` throws
  inside the `TC.Control` constructor (`Cannot read properties of null (reading
  'classList')`) and **no print button appears at all**. The seed `logo` is an external
  URL, dropped as well so the test does not leave the local stack.

That `div` parameter looks like a genuine data defect rather than a test-only concern:
the same value is present in production data, so anyone enabling the print task from
that configuration gets a silently missing button. Worth a separate look; happy to open
an issue if useful.

## How it was verified

On a local stack with the viewer fix applied:

- with the fix — `viewer-print` passes;
- with the fix reverted — it fails with `Expected: "1040px" / Received: "1600px"`, and
  the failure log shows the element already carrying
  `tc-ctl-prnmap-printing tc-ctl-prnmap-landscape-a4`, i.e. print mode active and the
  map still at window width;
- with the fix restored — passes again.

The full `playwright.viewer.config.ts` suite was run to check the shared setup change
does not disturb the other projects, including the #135 map-chrome layout tests.